### PR TITLE
bugfix: deadlock

### DIFF
--- a/examples/3_find_primes.ipynb
+++ b/examples/3_find_primes.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -25,6 +25,7 @@
     "import sprite2\n",
     "import numpy as np\n",
     "from matplotlib import pyplot as plt\n",
+    "from dask.diagnostics import ProgressBar\n",
     "import sprite2.aws\n",
     "import sprite2.dask\n",
     "import os\n",
@@ -34,152 +35,81 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# set up logging\n",
     "logging.basicConfig(\n",
     "    level=logging.DEBUG,\n",
-    "    format='%(levelname)-5s %(asctime)s %(threadName)s: %(message)s')\n",
-    "logging.debug(\"test1\")\n",
-    "\n",
-    "root_logger = logging.getLogger()\n",
-    "root_logger.setLevel(logging.ERROR)\n",
-    "\n",
-    "logger = logging.getLogger('sprite2')\n",
-    "logger.setLevel(logging.INFO)"
+    "    format='%(levelname)-5s %(asctime)s %(name)s %(threadName)s: %(message)s')\n",
+    "logging.getLogger().setLevel(logging.ERROR)\n",
+    "logging.getLogger('botocore').setLevel(logging.ERROR)\n",
+    "logging.getLogger('sprite2').setLevel(logging.ERROR)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
+    "# primality test\n",
     "def is_prime(n):\n",
-    "    if n % 2 == 0 and n > 2: \n",
+    "    if n % 2 == 0 and n > 2:\n",
     "        return False\n",
-    "    return all(n % i for i in range(3, int(math.sqrt(n)) + 1, 2))\n",
-    "\n",
-    "def find_primes(rng):\n",
-    "    for i in rng:\n",
-    "        if is_prime(i):\n",
-    "            yield i"
+    "    return all(n % i for i in range(3, int(math.sqrt(n)) + 1, 2))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(100,\n",
-       " [range(0, 99999),\n",
-       "  range(100000, 199999),\n",
-       "  range(200000, 299999),\n",
-       "  range(300000, 399999),\n",
-       "  range(400000, 499999),\n",
-       "  range(500000, 599999),\n",
-       "  range(600000, 699999),\n",
-       "  range(700000, 799999),\n",
-       "  range(800000, 899999),\n",
-       "  range(900000, 999999)],\n",
-       " [range(9000000, 9099999),\n",
-       "  range(9100000, 9199999),\n",
-       "  range(9200000, 9299999),\n",
-       "  range(9300000, 9399999),\n",
-       "  range(9400000, 9499999),\n",
-       "  range(9500000, 9599999),\n",
-       "  range(9600000, 9699999),\n",
-       "  range(9700000, 9799999),\n",
-       "  range(9800000, 9899999),\n",
-       "  range(9900000, 9999999)])"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# create 100 ranges of 100,000 numbers\n",
-    "start = 0\n",
-    "stop = 10000000\n",
-    "size = 100000\n",
-    "ranges = [range(i,i+size-1) for i in range(start, stop, size)]\n",
-    "len(ranges), ranges[:10],ranges[-10:]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# for each range, map over range with find_prime function, flatten results\n",
-    "d = (db.from_sequence(ranges, partition_size=1)\n",
-    "      .map(find_primes)\n",
-    "      .flatten())"
+    "# chunk 100 million\n",
+    "d = (db.range(100000000, npartitions=100)\n",
+    "       .filter(is_prime)\n",
+    "       .count())"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 238 ms, sys: 50.9 ms, total: 288 ms\n",
-      "Wall time: 41.6 s\n"
+      "[########################################] | 100% Completed | 46.5s\n"
      ]
     }
    ],
    "source": [
-    "# compute on local machine using multiprocessing (all cores)\n",
-    "%time primes = d.compute()"
+    "# compute result\n",
+    "with ProgressBar():\n",
+    "    result = d.compute(get=sprite2.dask.get)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 1.65 s, sys: 218 ms, total: 1.87 s\n",
-      "Wall time: 3.79 s\n"
-     ]
-    }
-   ],
-   "source": [
-    "# compute on lambda, takes significantly less time\n",
-    "%time primes = d.compute(get=sprite2.dask.get)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(216809, [0, 1, 2, 3, 5], [2999911, 2999921, 2999933, 2999951, 2999957])"
+       "5761457"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "len(primes), primes[:5], primes[-5:]"
+    "result"
    ]
   },
   {

--- a/examples/primes.py
+++ b/examples/primes.py
@@ -1,0 +1,34 @@
+from pprint import pprint
+from dask import bag as db
+from dask.diagnostics import ProgressBar
+import sprite2
+import sprite2.aws
+import sprite2.dask
+import math
+import logging
+
+# set up logging
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(levelname)-5s %(asctime)s %(name)s %(threadName)s: %(message)s')
+logging.getLogger().setLevel(logging.ERROR)
+logging.getLogger('botocore').setLevel(logging.ERROR)
+logging.getLogger('sprite2').setLevel(logging.ERROR)
+
+
+# primality test
+def is_prime(n):
+    if n % 2 == 0 and n > 2:
+        return False
+    return all(n % i for i in range(3, int(math.sqrt(n)) + 1, 2))
+
+
+# chunk 10 million
+d = (db.range(100000000, npartitions=100)
+       .filter(is_prime)
+       .count())
+
+# compute result
+with ProgressBar():
+    result = d.compute(get=sprite2.dask.get)
+print(result)

--- a/sprite2/dask.py
+++ b/sprite2/dask.py
@@ -1,8 +1,10 @@
 from functools import partial
 import logging
-import concurrent
+import concurrent.futures
+import sys
 
 from dask.local import get_async
+import boto3
 
 import sprite2
 
@@ -10,55 +12,62 @@ import sprite2
 logger = logging.getLogger(__name__)
 
 
-def apply_sync_lambda(
-        func,
-        args=(),
-        kwds={},
-        callback=None,
+def apply_sync_lambda_factory(
         invoker=sprite2.aws.remote,
-        lambda_name='sprite',
         ):
-    key, task_info, dumps, loads, get_id, pack_exception = args
-    func_wrapper = sprite2.aws.remote_invoke(
-        func=func,
-        lambda_name=lambda_name,
-        invoker=invoker,
-        request_id=key)
-    res = func_wrapper(*args, **kwds)
-    if callback is not None:
-        callback(res)
+    def inner(
+            func,
+            args=(),
+            kwds={},
+            callback=None,
+            ):
+        key, _, _, _, _, _ = args
+        logger.debug(f"executing task: {key}")
+        func_wrapper = sprite2.aws.remote_invoke(
+            func=func,
+            invoker=invoker,
+            request_id=key)
+        try:
+            res = func_wrapper(*args, **kwds)
+        except BaseException as e:
+            result = e, sys.exc_info()[2]
+            failed = True
+            res = key, result, failed
+        if callback is not None:
+            callback(res)
+            logger.debug(f'callback with result {str(res)[:100]}')
+    return inner
 
 
-def apply_async_lambda(
-        func,
-        args=(),
-        kwds={},
-        callback=None,
+def apply_async_lambda_factory(
         executor=None,
         invoker=sprite2.aws.remote,
-        lambda_name='sprite',
         ):
-    key, task_info, dumps, loads, get_id, pack_exception = args
-    task = lambda: apply_sync_lambda(func, args, kwds, callback, invoker, lambda_name)  # noqa
-    executor.submit(task)
+    def inner(
+            func,
+            args=(),
+            kwds={},
+            callback=None,
+            ):
+        key, _, _, _, _, _ = args
+        task = lambda: apply_sync_lambda_factory(invoker)(func, args, kwds, callback)  # noqa
+        executor.submit(task)
+    return inner
 
 
 def get(dsk, keys, **kwargs):
     num_workers = kwargs.pop('num_workers', 1000)
     lambda_name = kwargs.pop('lambda_name', 'sprite')
     invoker = kwargs.pop('invoker', sprite2.aws.remote)
+    invoker = partial(invoker, lambda_name=lambda_name)
     if num_workers and num_workers > 1:
         executor = concurrent.futures.ThreadPoolExecutor(num_workers)
-        apply = partial(
-            apply_async_lambda,
+        apply = apply_async_lambda_factory(
             executor=executor,
             invoker=invoker,
-            lambda_name=lambda_name,
             )
     else:
-        apply = partial(
-            apply_sync_lambda,
+        apply = apply_sync_lambda_factory(
             invoker=invoker,
-            lambda_name=lambda_name,
             )
     return get_async(apply, num_workers, dsk, keys, **kwargs)


### PR DESCRIPTION
## notes
ughh, this was a nightmare:
1. gdb stacks did not indicate deadlock
1. It was actually an issue with aws.  boto3 client was throwing an exception *intermittently*.   These exceptions were being swallowed and the thread would be re-allocated to the pool.  
1. bubbling up these exceptions to main thread is not documented anywhere in dask

## red herrings:
https://github.com/boto/boto3/issues/454
https://github.com/boto/boto3/issues/801

## canonical boto3 multithreading:
http://boto3.readthedocs.io/en/latest/guide/resources.html#multithreading-multiprocessing.

## 100 million prime numbers
I also dropped in a new prime number search example... shit is so hot:
```
$ AWS_PROFILE=personal AWS_DEFAULT_REGION=us-east-1 python examples/primes.py
[########################################] | 100% Completed | 43.7s
5761457
```